### PR TITLE
add cursor and filter patients by cursor

### DIFF
--- a/jobs/wf2-1-getPatients.js
+++ b/jobs/wf2-1-getPatients.js
@@ -1,8 +1,29 @@
+// here we define the date cursor
+fn(state => {
+  const manualCursor = '2023-05-18T20:16:37.000+0000';
+
+  const cursor =
+    state.lastRunDateTime != null && state.lastRunDateTime != ''
+      ? state.lastRunDateTime
+      : manualCursor;
+
+  console.log('Date cursor to filter & get only new encounters ::', cursor);
+
+  return { ...state, cursor };
+});
+
 searchPatient({ q: '1000EJC', v: 'full' });
 //Query all patients (q=all) not supported on demo OpenMRS; needs to be configured
 //...so we query all Patients with name "Patient" instead
 
 fn(state => {
   const { body } = state.data;
-  return { ...state, data: {}, references: [], patients: body.results };
+  const patients = body.results.filter(
+    patient => patient.auditInfo.dateCreated > state.cursor
+  );
+
+  const lastRunDateTime = new Date().toISOString();
+  console.log('Next sync start date:', lastRunDateTime);
+
+  return { ...state, data: {}, references: [], patients, lastRunDateTime };
 });


### PR DESCRIPTION
### Summary 
Add `cursor` in `jobs/wf2-1-getPatients.js` and filter patients by cursor. The filtering criteria is `auditInfo.dateCreated > lastRunTime || "2023-05-18T20:16:37.000+0000"`

Fixes #11 